### PR TITLE
Added support for Scala 2.12

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,6 +2,6 @@ name := "hashids-scala"
 
 organization := "io.john-ky"
 
-crossScalaVersions := Seq("2.10.5", "2.11.6")
+crossScalaVersions := Seq("2.10.5", "2.11.6", "2.12.1")
 
 version in ThisBuild := buildVersion

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -2,9 +2,9 @@ import sbt._
 import Keys._
 
 object Build extends Build with Version {
-  val specs2_core       = "org.specs2"      %%  "specs2-core"         % "3.6.2"
-  val specs2_scalacheck = "org.specs2"      %%  "specs2-scalacheck"   % "3.6.2"
-  val scalacheck        = "org.scalacheck"  %%  "scalacheck"          % "1.12.4"
+  val specs2_core       = "org.specs2"      %%  "specs2-core"         % "3.8.8"
+  val specs2_scalacheck = "org.specs2"      %%  "specs2-scalacheck"   % "3.8.8"
+  val scalacheck        = "org.scalacheck"  %%  "scalacheck"          % "1.12.6"
 
   implicit class ProjectOps(self: Project) {
     def standard: Project = {


### PR DESCRIPTION
I added the `2.12.1` Scala version to the `crossScalaVersions` and updated some libraries to a newer version as the previously used ones don't exist for Scala 2.12.
The compilation and the tests where successfully when I ran it locally.